### PR TITLE
Add transaction to containerd

### DIFF
--- a/supervisor/exit.go
+++ b/supervisor/exit.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -69,6 +70,17 @@ type ExecExitTask struct {
 
 func (s *Supervisor) execExit(t *ExecExitTask) error {
 	container := t.Process.Container()
+
+	now := time.Now()
+	transaction, err := s.transactionFactory.OpenTransaction(t.ID,
+		ExitTransaction,
+		WithTransactionMetadata("pid", t.PID),
+		WithTransactionMetadata("status", t.Status),
+		WithTransactionTimestamp(now))
+	if err != nil {
+		return err
+	}
+
 	// exec process: we remove this process without notifying the main event loop
 	if err := container.RemoveProcess(t.PID); err != nil {
 		logrus.WithField("error", err).Error("containerd: find container for pid")
@@ -81,13 +93,41 @@ func (s *Supervisor) execExit(t *ExecExitTask) error {
 	go func() {
 		t.Process.Wait()
 		s.notifySubscribers(Event{
-			Timestamp: time.Now(),
-			ID:        t.ID,
-			Type:      StateExit,
-			PID:       t.PID,
-			Status:    t.Status,
+			Timestamp:     now,
+			ID:            t.ID,
+			Type:          StateExit,
+			PID:           t.PID,
+			Status:        t.Status,
+			TransactionID: transaction.TransactionID(),
 		})
 		close(synCh)
 	}()
+	return nil
+}
+
+// HandleExitTransaction handles the container or process exit transaction
+func (s *Supervisor) HandleExitTransaction(transaction Transaction) error {
+	meta := transaction.MetaData()
+	if _, ok := meta["pid"]; !ok {
+		return fmt.Errorf("containerd: handle exit transaction error: lack of pid")
+	}
+	if _, ok := meta["pid"].(string); !ok {
+		return fmt.Errorf("containerd: handle exit transaction error: pid can not convert to string")
+	}
+	if _, ok := meta["status"]; !ok {
+		return fmt.Errorf("containerd: handle exit transaction error: lack of status")
+	}
+	if _, ok := meta["status"].(float64); !ok {
+		return fmt.Errorf("containerd: handle exit transaction error: status can not convert to float64")
+	}
+
+	s.notifySubscribers(Event{
+		Timestamp: transaction.TimeStamp(),
+		ID:        transaction.ContainerID(),
+		Type:      StateExit,
+		PID:       meta["pid"].(string),
+		Status:    uint32(meta["status"].(float64)),
+	})
+
 	return nil
 }

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -42,6 +42,15 @@ func New(stateDir string, runtimeName, shimName string, runtimeArgs []string, ti
 		timeout:           timeout,
 		containerExecSync: make(map[string]map[string]chan struct{}),
 	}
+	factory, err := NewTransactionFactory(filepath.Dir(stateDir),
+		WithOption(PauseTransaction, s.HandlePauseTransaction),
+		WithOption(ResumeTransaction, s.HandleResumeTransaction),
+		WithOption(ExitTransaction, s.HandleExitTransaction))
+	if err != nil {
+		return nil, err
+	}
+	s.transactionFactory = factory
+
 	if err := setupEventLog(s, retainCount); err != nil {
 		return nil, err
 	}
@@ -77,6 +86,17 @@ func eventLogger(s *Supervisor, path string, events chan Event, retainCount int)
 			enc   = json.NewEncoder(f)
 		)
 		for e := range events {
+			if e.TransactionID != 0 {
+				// event saved in event.log now, we could close the transaction:
+				transaction, err := s.transactionFactory.GetTransaction(e.TransactionID)
+				if err != nil {
+					logrus.WithField("error", err).Errorf("containerd: failed to get transaction for transactionID %d", e.TransactionID)
+				}
+				if transaction != nil {
+					transaction.Close()
+				}
+			}
+
 			// if we have a specified retain count make sure the truncate the event
 			// log if it grows past the specified number of events to keep.
 			if retainCount > 0 {
@@ -173,6 +193,8 @@ type Supervisor struct {
 	// before the init process death
 	containerExecSyncLock sync.Mutex
 	containerExecSync     map[string]map[string]chan struct{}
+	// Transaction factory is response to handle transaction for container operations in containerd
+	transactionFactory TransactionFactory
 }
 
 // Stop closes all startTasks and sends a SIGTERM to each container's pid1 then waits for they to
@@ -191,11 +213,12 @@ func (s *Supervisor) Close() error {
 
 // Event represents a container event
 type Event struct {
-	ID        string    `json:"id"`
-	Type      string    `json:"type"`
-	Timestamp time.Time `json:"timestamp"`
-	PID       string    `json:"pid,omitempty"`
-	Status    uint32    `json:"status,omitempty"`
+	ID            string    `json:"id"`
+	Type          string    `json:"type"`
+	Timestamp     time.Time `json:"timestamp"`
+	PID           string    `json:"pid,omitempty"`
+	Status        uint32    `json:"status,omitempty"`
+	TransactionID int64     `json:"-"`
 }
 
 type eventV1 struct {
@@ -363,6 +386,10 @@ func (s *Supervisor) restore() error {
 				s.newExecSyncChannel(container.ID(), p.ID())
 			}
 		}
+
+		// Handle transaction need before handle process exit
+		// As exit is the real states of a container.
+		s.transactionFactory.HandleTransaction(id)
 		if len(exitedProcesses) > 0 {
 			// sort processes so that init is fired last because that is how the kernel sends the
 			// exit events

--- a/supervisor/transaction.go
+++ b/supervisor/transaction.go
@@ -1,0 +1,169 @@
+package supervisor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// PauseTransaction stands for the pause transaction
+	PauseTransaction = "transaction-pause"
+	// ResumeTransaction stands for the resume transaction
+	ResumeTransaction = "transaction-resume"
+	// ExitTransaction stands for the signal transaction
+	ExitTransaction = "transaction-exit"
+)
+
+var (
+	// ErrTransactionTypeNotSupported means the transaction type is not supported error
+	ErrTransactionTypeNotSupported = errors.New("Transaction type not supported")
+	// ErrTransactionKeyExist means the transaction type conflicts
+	ErrTransactionKeyExist = errors.New("Transaction key exists")
+)
+
+func getTransactionID(path string) (int64, error) {
+	ids := strings.SplitN(path, "-", 2)
+	if len(ids) < 2 {
+		return -1, fmt.Errorf("containerd: invalid path %s to parse transaction id", path)
+	}
+	return strconv.ParseInt(ids[1], 10, 64)
+}
+
+// Transaction is the interface for transaction abstract
+type Transaction interface {
+	// Close will close a transaction
+	Close() error
+	// ContainerID returns the container id of the transaction
+	ContainerID() string
+	// TransactionID returns the transaction ID of the transaction.
+	// Each transaction has a unique ID.
+	TransactionID() int64
+	// MetaData returns the metadata for the transaction.
+	// It will hold the transaction parameter of the transaction:
+	// For example:
+	//    Sginal transaction need to save signal nunber and PID parameters to transaction.
+	MetaData() map[string]interface{}
+	// TimeStamp returns the time of the transaction opened
+	TimeStamp() time.Time
+}
+
+type transaction struct {
+	transactionID   int64
+	transactionType string
+	root            string
+	containerID     string
+	factory         TransactionFactory
+	Metadata        map[string]interface{} `json:"metadata"`
+	Timestamp       time.Time              `json:"timestamp"`
+}
+
+func (t *transaction) filePath() string {
+	return filepath.Join(t.root, t.containerID, t.transactionType, fmt.Sprintf("transaction-%d", t.transactionID))
+}
+
+// Close will close a transaction
+func (t *transaction) Close() error {
+	os.RemoveAll(t.filePath())
+	return t.factory.RemoveTransaction(t.transactionID)
+}
+
+// ContainerID returns the container id of the transaction
+func (t *transaction) ContainerID() string {
+	return t.containerID
+}
+
+// TransactionID returns the transaction ID of the transaction.
+func (t *transaction) TransactionID() int64 {
+	return t.transactionID
+}
+
+// MetaData returns the metadata for the transaction.
+func (t *transaction) MetaData() map[string]interface{} {
+	return t.Metadata
+}
+
+// TimeStamp returns the time of the transaction opened
+func (t *transaction) TimeStamp() time.Time {
+	return t.Timestamp
+}
+
+// TransactionMetadata will handle the metadata parameter
+type TransactionMetadata interface {
+	// Apply will apply the transaction metada options to Transaction.
+	Apply(Transaction) error
+}
+
+type transactionMetadata struct {
+	key   string
+	value interface{}
+}
+
+// WithTransactionMetadata handles the transaction metada options.
+func WithTransactionMetadata(key string, value interface{}) TransactionMetadata {
+	return &transactionMetadata{
+		key:   key,
+		value: value,
+	}
+}
+
+// Apply will apply the transaction metada options to Transaction.
+func (metadata *transactionMetadata) Apply(t Transaction) error {
+	if transaction, ok := t.(*transaction); ok {
+		if _, exist := transaction.Metadata[metadata.key]; exist {
+			return ErrTransactionKeyExist
+		}
+		transaction.Metadata[metadata.key] = metadata.value
+		return nil
+	}
+	return fmt.Errorf("Transaction Option not supported for this transaction")
+}
+
+// TransactionTimestamp will handle the transaction timestamp
+type TransactionTimestamp interface {
+	Apply(Transaction) error
+}
+
+type transactionTimestamp struct {
+	timestamp time.Time
+}
+
+// Apply will apply the transaction timestamp option for Transaction.
+func (ts *transactionTimestamp) Apply(t Transaction) error {
+	if transaction, ok := t.(*transaction); ok {
+		transaction.Timestamp = ts.timestamp
+		return nil
+	}
+	return fmt.Errorf("Transaction timestamp not supported for this transaction")
+}
+
+// WithTransactionTimestamp handles the transaction timestamp options.
+func WithTransactionTimestamp(ts time.Time) TransactionTimestamp {
+	return &transactionTimestamp{
+		timestamp: ts,
+	}
+}
+
+// SortedTransaction is used to sort the transaction.
+// Maybe there are more than one transactions opened before containerd creash,
+// We must make sure the sequence of the transactions to be executed.
+type SortedTransaction []*transaction
+
+// Len returns the lenghth of the SortedTransaction
+func (s SortedTransaction) Len() int {
+	return len([]*transaction(s))
+}
+
+// Swap swaps two elements in SortedTransaction
+func (s SortedTransaction) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less returns if the first element is 'less than' the second one
+func (s SortedTransaction) Less(i, j int) bool {
+	return s[i].Timestamp.Before(s[j].Timestamp)
+}

--- a/supervisor/transaction_factory.go
+++ b/supervisor/transaction_factory.go
@@ -1,0 +1,210 @@
+package supervisor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/ioutils"
+)
+
+// Option will handle the TransactionFactory options
+type Option interface {
+	// Apply will apply the transactionFactory options to TransactionFactory
+	Apply(TransactionFactory) error
+}
+
+type transactionFactoryOptions struct {
+	transactionType string
+	handler         TransactionHandler
+}
+
+// Apply will apply the transactionFactory options to TransactionFactory
+func (op *transactionFactoryOptions) Apply(f TransactionFactory) error {
+	if factory, ok := f.(*transactionFactory); ok {
+		if _, exist := factory.handler[op.transactionType]; exist {
+			return ErrTransactionKeyExist
+
+		}
+		factory.handler[op.transactionType] = op.handler
+		return nil
+	}
+	return fmt.Errorf("Transaction Option not supported for this factory")
+}
+
+// WithOption returns the factory options
+func WithOption(transactionType string, handler TransactionHandler) Option {
+	return &transactionFactoryOptions{
+		handler:         handler,
+		transactionType: transactionType,
+	}
+}
+
+// TransactionHandler is a function type which used to handle different kinds of transaction
+type TransactionHandler func(Transaction) error
+
+// TransactionFactory is a interface which describes the transaction factory
+type TransactionFactory interface {
+	// OpenTransaction creates a new transaction
+	OpenTransaction(containerID, transactionType string, metadata ...TransactionMetadata) (Transaction, error)
+	// RemoveTransaction removes a transaction from transactionFactory
+	RemoveTransaction(int64) error
+	// HandleTransaction handles all the transactions for containerID when containerd startup
+	HandleTransaction(containerID string) error
+	// GetTransaction returns Transaction from id
+	GetTransaction(id int64) (Transaction, error)
+}
+
+type transactionFactory struct {
+	sync.Mutex
+	root         string
+	id           int64
+	handler      map[string]TransactionHandler
+	transactions map[int64]Transaction
+}
+
+// NewTransactionFactory creates the transaction factory
+func NewTransactionFactory(root string, options ...Option) (TransactionFactory, error) {
+	factory := &transactionFactory{
+		root:         root,
+		id:           1,
+		handler:      make(map[string]TransactionHandler),
+		transactions: make(map[int64]Transaction),
+	}
+	for _, option := range options {
+		if err := option.Apply(factory); err != nil {
+			return nil, err
+		}
+	}
+	return factory, nil
+}
+
+func (factory *transactionFactory) newTransactionID() int64 {
+	factory.Lock()
+	factory.id++
+	id := factory.id
+	factory.Unlock()
+	return id
+}
+
+func (factory *transactionFactory) addTransaction(t Transaction) error {
+	factory.Lock()
+	defer factory.Unlock()
+	if _, exist := factory.transactions[t.TransactionID()]; exist {
+		return fmt.Errorf("transaction id %d exist", t.TransactionID())
+	}
+	factory.transactions[t.TransactionID()] = t
+	return nil
+}
+
+// RemoveTransaction removes a transaction from transactionFactory
+func (factory *transactionFactory) RemoveTransaction(id int64) error {
+	factory.Lock()
+	delete(factory.transactions, id)
+	factory.Unlock()
+	return nil
+}
+
+// GetTransaction returns Transaction from id
+func (factory *transactionFactory) GetTransaction(id int64) (Transaction, error) {
+	factory.Lock()
+	defer factory.Unlock()
+	if transaction, exist := factory.transactions[id]; exist {
+		return transaction, nil
+	}
+	return nil, fmt.Errorf("transaction id %s does not exist", id)
+}
+
+// OpenTransaction creates a new transaction
+func (factory *transactionFactory) OpenTransaction(containerID, transactionType string, metadata ...TransactionMetadata) (Transaction, error) {
+	if _, exist := factory.handler[transactionType]; !exist {
+		return nil, ErrTransactionTypeNotSupported
+	}
+
+	transaction := &transaction{
+		root:            factory.root,
+		containerID:     containerID,
+		transactionType: transactionType,
+		transactionID:   factory.newTransactionID(),
+		Metadata:        make(map[string]interface{}),
+		factory:         factory,
+	}
+	for _, m := range metadata {
+		if err := m.Apply(transaction); err != nil {
+			return nil, err
+		}
+	}
+
+	os.MkdirAll(filepath.Dir(transaction.filePath()), 0600)
+	jsonData, err := json.Marshal(transaction)
+	if err != nil {
+		return nil, err
+	}
+	if err := ioutils.AtomicWriteFile(transaction.filePath(), jsonData, 0600); err != nil {
+		return nil, err
+	}
+	if err := factory.addTransaction(transaction); err != nil {
+		return nil, err
+	}
+
+	return transaction, nil
+}
+
+// HandleTransaction handles all the transactions for containerID when containerd startup
+func (factory *transactionFactory) HandleTransaction(containerID string) error {
+	var transactions []*transaction
+	for transactionType := range factory.handler {
+		path := filepath.Join(factory.root, containerID, transactionType)
+		if _, err := os.Stat(path); err == nil {
+			files, err := ioutil.ReadDir(path)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					logrus.Errorf("containerd: failed to read path %s, with error: %v", path, err)
+				}
+				continue
+			}
+
+			for _, file := range files {
+				if id, err := getTransactionID(file.Name()); err == nil {
+					transactionFile := filepath.Join(path, file.Name())
+					jsonData, err := ioutil.ReadFile(transactionFile)
+					if err != nil {
+						logrus.Errorf("containerd: failed to read file %s, with error: %v", transactionFile, err)
+						continue
+					}
+					transaction := &transaction{
+						transactionID:   id,
+						containerID:     containerID,
+						root:            factory.root,
+						transactionType: transactionType,
+						Metadata:        make(map[string]interface{}),
+						factory:         factory,
+					}
+					if err := json.Unmarshal(jsonData, transaction); err != nil {
+						logrus.Errorf("containerd: failed to decode transaction, with error: %v", err)
+						continue
+					}
+
+					transactions = append(transactions, transaction)
+				}
+			}
+		}
+	}
+
+	// here to sort transaction by Timestamp, we must make sure the sequence of transactions.
+	sort.Sort(SortedTransaction(transactions))
+	for _, t := range transactions {
+		tType := t.transactionType
+		logrus.Debugf("containerd: handling transaction for container %s, type %s, transactionID %d", t.containerID, t.transactionType, t.transactionID)
+		if err := factory.handler[tType](t); err != nil {
+			logrus.Errorf("containerd: transaction handler for %s, type %s error: %v", t.containerID, t.transactionType, err)
+		}
+		t.Close()
+	}
+	return nil
+}

--- a/vendor/src/github.com/docker/docker/pkg/ioutils/buffer.go
+++ b/vendor/src/github.com/docker/docker/pkg/ioutils/buffer.go
@@ -1,0 +1,51 @@
+package ioutils
+
+import (
+	"errors"
+	"io"
+)
+
+var errBufferFull = errors.New("buffer is full")
+
+type fixedBuffer struct {
+	buf      []byte
+	pos      int
+	lastRead int
+}
+
+func (b *fixedBuffer) Write(p []byte) (int, error) {
+	n := copy(b.buf[b.pos:cap(b.buf)], p)
+	b.pos += n
+
+	if n < len(p) {
+		if b.pos == cap(b.buf) {
+			return n, errBufferFull
+		}
+		return n, io.ErrShortWrite
+	}
+	return n, nil
+}
+
+func (b *fixedBuffer) Read(p []byte) (int, error) {
+	n := copy(p, b.buf[b.lastRead:b.pos])
+	b.lastRead += n
+	return n, nil
+}
+
+func (b *fixedBuffer) Len() int {
+	return b.pos - b.lastRead
+}
+
+func (b *fixedBuffer) Cap() int {
+	return cap(b.buf)
+}
+
+func (b *fixedBuffer) Reset() {
+	b.pos = 0
+	b.lastRead = 0
+	b.buf = b.buf[:0]
+}
+
+func (b *fixedBuffer) String() string {
+	return string(b.buf[b.lastRead:b.pos])
+}

--- a/vendor/src/github.com/docker/docker/pkg/ioutils/bytespipe.go
+++ b/vendor/src/github.com/docker/docker/pkg/ioutils/bytespipe.go
@@ -1,0 +1,180 @@
+package ioutils
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+// maxCap is the highest capacity to use in byte slices that buffer data.
+const maxCap = 1e6
+
+// minCap is the lowest capacity to use in byte slices that buffer data
+const minCap = 64
+
+// blockThreshold is the minimum number of bytes in the buffer which will cause
+// a write to BytesPipe to block when allocating a new slice.
+const blockThreshold = 1e6
+
+var (
+	// ErrClosed is returned when Write is called on a closed BytesPipe.
+	ErrClosed = errors.New("write to closed BytesPipe")
+
+	bufPools = make(map[int]*sync.Pool)
+)
+
+// BytesPipe is io.ReadWriteCloser which works similarly to pipe(queue).
+// All written data may be read at most once. Also, BytesPipe allocates
+// and releases new byte slices to adjust to current needs, so the buffer
+// won't be overgrown after peak loads.
+type BytesPipe struct {
+	mu       sync.Mutex
+	wait     *sync.Cond
+	buf      []*fixedBuffer
+	bufLen   int
+	closeErr error // error to return from next Read. set to nil if not closed.
+}
+
+// NewBytesPipe creates new BytesPipe, initialized by specified slice.
+// If buf is nil, then it will be initialized with slice which cap is 64.
+// buf will be adjusted in a way that len(buf) == 0, cap(buf) == cap(buf).
+func NewBytesPipe() *BytesPipe {
+	bp := &BytesPipe{}
+	bp.buf = append(bp.buf, getBuffer(minCap))
+	bp.wait = sync.NewCond(&bp.mu)
+	return bp
+}
+
+// Write writes p to BytesPipe.
+// It can allocate new []byte slices in a process of writing.
+func (bp *BytesPipe) Write(p []byte) (int, error) {
+	bp.mu.Lock()
+
+	written := 0
+loop0:
+	for {
+		if bp.closeErr != nil {
+			bp.mu.Unlock()
+			return written, ErrClosed
+		}
+
+		if len(bp.buf) == 0 {
+			bp.buf = append(bp.buf, getBuffer(64))
+		}
+		// get the last buffer
+		b := bp.buf[len(bp.buf)-1]
+
+		n, err := b.Write(p)
+		written += n
+		bp.bufLen += n
+
+		// errBufferFull is an error we expect to get if the buffer is full
+		if err != nil && err != errBufferFull {
+			bp.wait.Broadcast()
+			bp.mu.Unlock()
+			return written, err
+		}
+
+		// if there was enough room to write all then break
+		if len(p) == n {
+			break
+		}
+
+		// more data: write to the next slice
+		p = p[n:]
+
+		// make sure the buffer doesn't grow too big from this write
+		for bp.bufLen >= blockThreshold {
+			bp.wait.Wait()
+			if bp.closeErr != nil {
+				continue loop0
+			}
+		}
+
+		// add new byte slice to the buffers slice and continue writing
+		nextCap := b.Cap() * 2
+		if nextCap > maxCap {
+			nextCap = maxCap
+		}
+		bp.buf = append(bp.buf, getBuffer(nextCap))
+	}
+	bp.wait.Broadcast()
+	bp.mu.Unlock()
+	return written, nil
+}
+
+// CloseWithError causes further reads from a BytesPipe to return immediately.
+func (bp *BytesPipe) CloseWithError(err error) error {
+	bp.mu.Lock()
+	if err != nil {
+		bp.closeErr = err
+	} else {
+		bp.closeErr = io.EOF
+	}
+	bp.wait.Broadcast()
+	bp.mu.Unlock()
+	return nil
+}
+
+// Close causes further reads from a BytesPipe to return immediately.
+func (bp *BytesPipe) Close() error {
+	return bp.CloseWithError(nil)
+}
+
+// Read reads bytes from BytesPipe.
+// Data could be read only once.
+func (bp *BytesPipe) Read(p []byte) (n int, err error) {
+	bp.mu.Lock()
+	if bp.bufLen == 0 {
+		if bp.closeErr != nil {
+			bp.mu.Unlock()
+			return 0, bp.closeErr
+		}
+		bp.wait.Wait()
+		if bp.bufLen == 0 && bp.closeErr != nil {
+			bp.mu.Unlock()
+			return 0, bp.closeErr
+		}
+	}
+
+	for bp.bufLen > 0 {
+		b := bp.buf[0]
+		read, _ := b.Read(p) // ignore error since fixedBuffer doesn't really return an error
+		n += read
+		bp.bufLen -= read
+
+		if b.Len() == 0 {
+			// it's empty so return it to the pool and move to the next one
+			returnBuffer(b)
+			bp.buf[0] = nil
+			bp.buf = bp.buf[1:]
+		}
+
+		if len(p) == read {
+			break
+		}
+
+		p = p[read:]
+	}
+
+	bp.wait.Broadcast()
+	bp.mu.Unlock()
+	return
+}
+
+func returnBuffer(b *fixedBuffer) {
+	b.Reset()
+	pool := bufPools[b.Cap()]
+	if pool != nil {
+		pool.Put(b)
+	}
+}
+
+func getBuffer(size int) *fixedBuffer {
+	pool, ok := bufPools[size]
+	if !ok {
+		pool = &sync.Pool{New: func() interface{} { return &fixedBuffer{buf: make([]byte, 0, size)} }}
+		bufPools[size] = pool
+	}
+	return pool.Get().(*fixedBuffer)
+}

--- a/vendor/src/github.com/docker/docker/pkg/ioutils/fmt.go
+++ b/vendor/src/github.com/docker/docker/pkg/ioutils/fmt.go
@@ -1,0 +1,22 @@
+package ioutils
+
+import (
+	"fmt"
+	"io"
+)
+
+// FprintfIfNotEmpty prints the string value if it's not empty
+func FprintfIfNotEmpty(w io.Writer, format, value string) (int, error) {
+	if value != "" {
+		return fmt.Fprintf(w, format, value)
+	}
+	return 0, nil
+}
+
+// FprintfIfTrue prints the boolean value if it's true
+func FprintfIfTrue(w io.Writer, format string, ok bool) (int, error) {
+	if ok {
+		return fmt.Fprintf(w, format, ok)
+	}
+	return 0, nil
+}

--- a/vendor/src/github.com/docker/docker/pkg/ioutils/fswriters.go
+++ b/vendor/src/github.com/docker/docker/pkg/ioutils/fswriters.go
@@ -1,0 +1,75 @@
+package ioutils
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// NewAtomicFileWriter returns WriteCloser so that writing to it writes to a
+// temporary file and closing it atomically changes the temporary file to
+// destination path. Writing and closing concurrently is not allowed.
+func NewAtomicFileWriter(filename string, perm os.FileMode) (io.WriteCloser, error) {
+	f, err := ioutil.TempFile(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
+	if err != nil {
+		return nil, err
+	}
+	abspath, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, err
+	}
+	return &atomicFileWriter{
+		f:  f,
+		fn: abspath,
+	}, nil
+}
+
+// AtomicWriteFile atomically writes data to a file named by filename.
+func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
+	f, err := NewAtomicFileWriter(filename, perm)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write(data)
+	if err == nil && n < len(data) {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}
+
+type atomicFileWriter struct {
+	f        *os.File
+	fn       string
+	writeErr error
+}
+
+func (w *atomicFileWriter) Write(dt []byte) (int, error) {
+	n, err := w.f.Write(dt)
+	if err != nil {
+		w.writeErr = err
+	}
+	return n, err
+}
+
+func (w *atomicFileWriter) Close() (retErr error) {
+	defer func() {
+		if retErr != nil {
+			os.Remove(w.f.Name())
+		}
+	}()
+	if err := w.f.Sync(); err != nil {
+		w.f.Close()
+		return err
+	}
+	if err := w.f.Close(); err != nil {
+		return err
+	}
+	if w.writeErr == nil {
+		return os.Rename(w.f.Name(), w.fn)
+	}
+	return nil
+}

--- a/vendor/src/github.com/docker/docker/pkg/ioutils/multireader.go
+++ b/vendor/src/github.com/docker/docker/pkg/ioutils/multireader.go
@@ -1,0 +1,226 @@
+package ioutils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+)
+
+type pos struct {
+	idx    int
+	offset int64
+}
+
+type multiReadSeeker struct {
+	readers []io.ReadSeeker
+	pos     *pos
+	posIdx  map[io.ReadSeeker]int
+}
+
+func (r *multiReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	var tmpOffset int64
+	switch whence {
+	case os.SEEK_SET:
+		for i, rdr := range r.readers {
+			// get size of the current reader
+			s, err := rdr.Seek(0, os.SEEK_END)
+			if err != nil {
+				return -1, err
+			}
+
+			if offset > tmpOffset+s {
+				if i == len(r.readers)-1 {
+					rdrOffset := s + (offset - tmpOffset)
+					if _, err := rdr.Seek(rdrOffset, os.SEEK_SET); err != nil {
+						return -1, err
+					}
+					r.pos = &pos{i, rdrOffset}
+					return offset, nil
+				}
+
+				tmpOffset += s
+				continue
+			}
+
+			rdrOffset := offset - tmpOffset
+			idx := i
+
+			rdr.Seek(rdrOffset, os.SEEK_SET)
+			// make sure all following readers are at 0
+			for _, rdr := range r.readers[i+1:] {
+				rdr.Seek(0, os.SEEK_SET)
+			}
+
+			if rdrOffset == s && i != len(r.readers)-1 {
+				idx++
+				rdrOffset = 0
+			}
+			r.pos = &pos{idx, rdrOffset}
+			return offset, nil
+		}
+	case os.SEEK_END:
+		for _, rdr := range r.readers {
+			s, err := rdr.Seek(0, os.SEEK_END)
+			if err != nil {
+				return -1, err
+			}
+			tmpOffset += s
+		}
+		r.Seek(tmpOffset+offset, os.SEEK_SET)
+		return tmpOffset + offset, nil
+	case os.SEEK_CUR:
+		if r.pos == nil {
+			return r.Seek(offset, os.SEEK_SET)
+		}
+		// Just return the current offset
+		if offset == 0 {
+			return r.getCurOffset()
+		}
+
+		curOffset, err := r.getCurOffset()
+		if err != nil {
+			return -1, err
+		}
+		rdr, rdrOffset, err := r.getReaderForOffset(curOffset + offset)
+		if err != nil {
+			return -1, err
+		}
+
+		r.pos = &pos{r.posIdx[rdr], rdrOffset}
+		return curOffset + offset, nil
+	default:
+		return -1, fmt.Errorf("Invalid whence: %d", whence)
+	}
+
+	return -1, fmt.Errorf("Error seeking for whence: %d, offset: %d", whence, offset)
+}
+
+func (r *multiReadSeeker) getReaderForOffset(offset int64) (io.ReadSeeker, int64, error) {
+	var rdr io.ReadSeeker
+	var rdrOffset int64
+
+	for i, rdr := range r.readers {
+		offsetTo, err := r.getOffsetToReader(rdr)
+		if err != nil {
+			return nil, -1, err
+		}
+		if offsetTo > offset {
+			rdr = r.readers[i-1]
+			rdrOffset = offsetTo - offset
+			break
+		}
+
+		if rdr == r.readers[len(r.readers)-1] {
+			rdrOffset = offsetTo + offset
+			break
+		}
+	}
+
+	return rdr, rdrOffset, nil
+}
+
+func (r *multiReadSeeker) getCurOffset() (int64, error) {
+	var totalSize int64
+	for _, rdr := range r.readers[:r.pos.idx+1] {
+		if r.posIdx[rdr] == r.pos.idx {
+			totalSize += r.pos.offset
+			break
+		}
+
+		size, err := getReadSeekerSize(rdr)
+		if err != nil {
+			return -1, fmt.Errorf("error getting seeker size: %v", err)
+		}
+		totalSize += size
+	}
+	return totalSize, nil
+}
+
+func (r *multiReadSeeker) getOffsetToReader(rdr io.ReadSeeker) (int64, error) {
+	var offset int64
+	for _, r := range r.readers {
+		if r == rdr {
+			break
+		}
+
+		size, err := getReadSeekerSize(rdr)
+		if err != nil {
+			return -1, err
+		}
+		offset += size
+	}
+	return offset, nil
+}
+
+func (r *multiReadSeeker) Read(b []byte) (int, error) {
+	if r.pos == nil {
+		r.pos = &pos{0, 0}
+	}
+
+	bCap := int64(cap(b))
+	buf := bytes.NewBuffer(nil)
+	var rdr io.ReadSeeker
+
+	for _, rdr = range r.readers[r.pos.idx:] {
+		readBytes, err := io.CopyN(buf, rdr, bCap)
+		if err != nil && err != io.EOF {
+			return -1, err
+		}
+		bCap -= readBytes
+
+		if bCap == 0 {
+			break
+		}
+	}
+
+	rdrPos, err := rdr.Seek(0, os.SEEK_CUR)
+	if err != nil {
+		return -1, err
+	}
+	r.pos = &pos{r.posIdx[rdr], rdrPos}
+	return buf.Read(b)
+}
+
+func getReadSeekerSize(rdr io.ReadSeeker) (int64, error) {
+	// save the current position
+	pos, err := rdr.Seek(0, os.SEEK_CUR)
+	if err != nil {
+		return -1, err
+	}
+
+	// get the size
+	size, err := rdr.Seek(0, os.SEEK_END)
+	if err != nil {
+		return -1, err
+	}
+
+	// reset the position
+	if _, err := rdr.Seek(pos, os.SEEK_SET); err != nil {
+		return -1, err
+	}
+	return size, nil
+}
+
+// MultiReadSeeker returns a ReadSeeker that's the logical concatenation of the provided
+// input readseekers. After calling this method the initial position is set to the
+// beginning of the first ReadSeeker. At the end of a ReadSeeker, Read always advances
+// to the beginning of the next ReadSeeker and returns EOF at the end of the last ReadSeeker.
+// Seek can be used over the sum of lengths of all readseekers.
+//
+// When a MultiReadSeeker is used, no Read and Seek operations should be made on
+// its ReadSeeker components. Also, users should make no assumption on the state
+// of individual readseekers while the MultiReadSeeker is used.
+func MultiReadSeeker(readers ...io.ReadSeeker) io.ReadSeeker {
+	if len(readers) == 1 {
+		return readers[0]
+	}
+	idx := make(map[io.ReadSeeker]int)
+	for i, rdr := range readers {
+		idx[rdr] = i
+	}
+	return &multiReadSeeker{
+		readers: readers,
+		posIdx:  idx,
+	}
+}

--- a/vendor/src/github.com/docker/docker/pkg/ioutils/readers.go
+++ b/vendor/src/github.com/docker/docker/pkg/ioutils/readers.go
@@ -1,0 +1,154 @@
+package ioutils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+
+	"golang.org/x/net/context"
+)
+
+type readCloserWrapper struct {
+	io.Reader
+	closer func() error
+}
+
+func (r *readCloserWrapper) Close() error {
+	return r.closer()
+}
+
+// NewReadCloserWrapper returns a new io.ReadCloser.
+func NewReadCloserWrapper(r io.Reader, closer func() error) io.ReadCloser {
+	return &readCloserWrapper{
+		Reader: r,
+		closer: closer,
+	}
+}
+
+type readerErrWrapper struct {
+	reader io.Reader
+	closer func()
+}
+
+func (r *readerErrWrapper) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if err != nil {
+		r.closer()
+	}
+	return n, err
+}
+
+// NewReaderErrWrapper returns a new io.Reader.
+func NewReaderErrWrapper(r io.Reader, closer func()) io.Reader {
+	return &readerErrWrapper{
+		reader: r,
+		closer: closer,
+	}
+}
+
+// HashData returns the sha256 sum of src.
+func HashData(src io.Reader) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, src); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// OnEOFReader wraps a io.ReadCloser and a function
+// the function will run at the end of file or close the file.
+type OnEOFReader struct {
+	Rc io.ReadCloser
+	Fn func()
+}
+
+func (r *OnEOFReader) Read(p []byte) (n int, err error) {
+	n, err = r.Rc.Read(p)
+	if err == io.EOF {
+		r.runFunc()
+	}
+	return
+}
+
+// Close closes the file and run the function.
+func (r *OnEOFReader) Close() error {
+	err := r.Rc.Close()
+	r.runFunc()
+	return err
+}
+
+func (r *OnEOFReader) runFunc() {
+	if fn := r.Fn; fn != nil {
+		fn()
+		r.Fn = nil
+	}
+}
+
+// cancelReadCloser wraps an io.ReadCloser with a context for cancelling read
+// operations.
+type cancelReadCloser struct {
+	cancel func()
+	pR     *io.PipeReader // Stream to read from
+	pW     *io.PipeWriter
+}
+
+// NewCancelReadCloser creates a wrapper that closes the ReadCloser when the
+// context is cancelled. The returned io.ReadCloser must be closed when it is
+// no longer needed.
+func NewCancelReadCloser(ctx context.Context, in io.ReadCloser) io.ReadCloser {
+	pR, pW := io.Pipe()
+
+	// Create a context used to signal when the pipe is closed
+	doneCtx, cancel := context.WithCancel(context.Background())
+
+	p := &cancelReadCloser{
+		cancel: cancel,
+		pR:     pR,
+		pW:     pW,
+	}
+
+	go func() {
+		_, err := io.Copy(pW, in)
+		select {
+		case <-ctx.Done():
+			// If the context was closed, p.closeWithError
+			// was already called. Calling it again would
+			// change the error that Read returns.
+		default:
+			p.closeWithError(err)
+		}
+		in.Close()
+	}()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				p.closeWithError(ctx.Err())
+			case <-doneCtx.Done():
+				return
+			}
+		}
+	}()
+
+	return p
+}
+
+// Read wraps the Read method of the pipe that provides data from the wrapped
+// ReadCloser.
+func (p *cancelReadCloser) Read(buf []byte) (n int, err error) {
+	return p.pR.Read(buf)
+}
+
+// closeWithError closes the wrapper and its underlying reader. It will
+// cause future calls to Read to return err.
+func (p *cancelReadCloser) closeWithError(err error) {
+	p.pW.CloseWithError(err)
+	p.cancel()
+}
+
+// Close closes the wrapper its underlying reader. It will cause
+// future calls to Read to return io.EOF.
+func (p *cancelReadCloser) Close() error {
+	p.closeWithError(io.EOF)
+	return nil
+}

--- a/vendor/src/github.com/docker/docker/pkg/ioutils/temp_unix.go
+++ b/vendor/src/github.com/docker/docker/pkg/ioutils/temp_unix.go
@@ -1,0 +1,10 @@
+// +build !windows
+
+package ioutils
+
+import "io/ioutil"
+
+// TempDir on Unix systems is equivalent to ioutil.TempDir.
+func TempDir(dir, prefix string) (string, error) {
+	return ioutil.TempDir(dir, prefix)
+}

--- a/vendor/src/github.com/docker/docker/pkg/ioutils/temp_windows.go
+++ b/vendor/src/github.com/docker/docker/pkg/ioutils/temp_windows.go
@@ -1,0 +1,18 @@
+// +build windows
+
+package ioutils
+
+import (
+	"io/ioutil"
+
+	"github.com/docker/docker/pkg/longpath"
+)
+
+// TempDir is the equivalent of ioutil.TempDir, except that the result is in Windows longpath format.
+func TempDir(dir, prefix string) (string, error) {
+	tempDir, err := ioutil.TempDir(dir, prefix)
+	if err != nil {
+		return "", err
+	}
+	return longpath.AddPrefix(tempDir), nil
+}

--- a/vendor/src/github.com/docker/docker/pkg/ioutils/writeflusher.go
+++ b/vendor/src/github.com/docker/docker/pkg/ioutils/writeflusher.go
@@ -1,0 +1,92 @@
+package ioutils
+
+import (
+	"io"
+	"sync"
+)
+
+// WriteFlusher wraps the Write and Flush operation ensuring that every write
+// is a flush. In addition, the Close method can be called to intercept
+// Read/Write calls if the targets lifecycle has already ended.
+type WriteFlusher struct {
+	w           io.Writer
+	flusher     flusher
+	flushed     chan struct{}
+	flushedOnce sync.Once
+	closed      chan struct{}
+	closeLock   sync.Mutex
+}
+
+type flusher interface {
+	Flush()
+}
+
+var errWriteFlusherClosed = io.EOF
+
+func (wf *WriteFlusher) Write(b []byte) (n int, err error) {
+	select {
+	case <-wf.closed:
+		return 0, errWriteFlusherClosed
+	default:
+	}
+
+	n, err = wf.w.Write(b)
+	wf.Flush() // every write is a flush.
+	return n, err
+}
+
+// Flush the stream immediately.
+func (wf *WriteFlusher) Flush() {
+	select {
+	case <-wf.closed:
+		return
+	default:
+	}
+
+	wf.flushedOnce.Do(func() {
+		close(wf.flushed)
+	})
+	wf.flusher.Flush()
+}
+
+// Flushed returns the state of flushed.
+// If it's flushed, return true, or else it return false.
+func (wf *WriteFlusher) Flushed() bool {
+	// BUG(stevvooe): Remove this method. Its use is inherently racy. Seems to
+	// be used to detect whether or a response code has been issued or not.
+	// Another hook should be used instead.
+	var flushed bool
+	select {
+	case <-wf.flushed:
+		flushed = true
+	default:
+	}
+	return flushed
+}
+
+// Close closes the write flusher, disallowing any further writes to the
+// target. After the flusher is closed, all calls to write or flush will
+// result in an error.
+func (wf *WriteFlusher) Close() error {
+	wf.closeLock.Lock()
+	defer wf.closeLock.Unlock()
+
+	select {
+	case <-wf.closed:
+		return errWriteFlusherClosed
+	default:
+		close(wf.closed)
+	}
+	return nil
+}
+
+// NewWriteFlusher returns a new WriteFlusher.
+func NewWriteFlusher(w io.Writer) *WriteFlusher {
+	var fl flusher
+	if f, ok := w.(flusher); ok {
+		fl = f
+	} else {
+		fl = &NopFlusher{}
+	}
+	return &WriteFlusher{w: w, flusher: fl, closed: make(chan struct{}), flushed: make(chan struct{})}
+}

--- a/vendor/src/github.com/docker/docker/pkg/ioutils/writers.go
+++ b/vendor/src/github.com/docker/docker/pkg/ioutils/writers.go
@@ -1,0 +1,66 @@
+package ioutils
+
+import "io"
+
+// NopWriter represents a type which write operation is nop.
+type NopWriter struct{}
+
+func (*NopWriter) Write(buf []byte) (int, error) {
+	return len(buf), nil
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (w *nopWriteCloser) Close() error { return nil }
+
+// NopWriteCloser returns a nopWriteCloser.
+func NopWriteCloser(w io.Writer) io.WriteCloser {
+	return &nopWriteCloser{w}
+}
+
+// NopFlusher represents a type which flush operation is nop.
+type NopFlusher struct{}
+
+// Flush is a nop operation.
+func (f *NopFlusher) Flush() {}
+
+type writeCloserWrapper struct {
+	io.Writer
+	closer func() error
+}
+
+func (r *writeCloserWrapper) Close() error {
+	return r.closer()
+}
+
+// NewWriteCloserWrapper returns a new io.WriteCloser.
+func NewWriteCloserWrapper(r io.Writer, closer func() error) io.WriteCloser {
+	return &writeCloserWrapper{
+		Writer: r,
+		closer: closer,
+	}
+}
+
+// WriteCounter wraps a concrete io.Writer and hold a count of the number
+// of bytes written to the writer during a "session".
+// This can be convenient when write return is masked
+// (e.g., json.Encoder.Encode())
+type WriteCounter struct {
+	Count  int64
+	Writer io.Writer
+}
+
+// NewWriteCounter returns a new WriteCounter.
+func NewWriteCounter(w io.Writer) *WriteCounter {
+	return &WriteCounter{
+		Writer: w,
+	}
+}
+
+func (wc *WriteCounter) Write(p []byte) (count int, err error) {
+	count, err = wc.Writer.Write(p)
+	wc.Count += int64(count)
+	return
+}


### PR DESCRIPTION
Why we need transaction in containerd:
   When docker send grpc messages to containerd, it always forward to exec runc to do something.
   And then send back a event to docker.

But if the containerd was killed or crashed after receving grpc message, before sending back the events.
These is no way to recover it. This may cause the data of container not the same between docker and containerd.

How to implement:
 We add a transaction mechanism:

* Open a transaction:
This will return a Transaction interface, When we open a transaction, will write the transaction data into disk by sync mode.
```
 transaction,err := transactionFactory.OpenTransaction(containerID, transactionType, otherMetada)
```

* Close the transaction:
when the event was sent to docker, the transaction will be closed (removing from disk and memory).
```
 transaction.Close()
```

Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>