### PR TITLE
[17.06.x] Vndr runtime spec with fix for int type of memory fields

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -14,8 +14,8 @@ clone git github.com/docker/go-units 5d2041e26a699eaca682e2ea41c8f891e1060444
 clone git github.com/godbus/dbus e2cf28118e66a6a63db46cf6088a35d2054d3bb0
 clone git github.com/golang/glog 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 clone git github.com/golang/protobuf 8ee79997227bf9b34611aee7946ae64735e6fd93
-clone git github.com/opencontainers/runc 992a5be178a62e026f4069f443c6164912adbf09
-clone git github.com/opencontainers/runtime-spec v1.0.0-rc5
+clone git github.com/opencontainers/runc 810190ceaa507aa2727d7ae6f4790c76ec150bd2 https://github.com/docker/runc
+clone git github.com/opencontainers/runtime-spec a45ba0989fc26c695fe166a49c45bb8b7618ab36 https://github.com/docker/runtime-spec
 clone git github.com/rcrowley/go-metrics eeba7bd0dd01ace6e690fa833b3f22aaec29af43
 clone git github.com/satori/go.uuid f9ab0dce87d815821e221626b772e3475a0d2749
 clone git github.com/syndtr/gocapability 2c00daeb6c3b45114c80ac44119e7b8801fdd852

--- a/integration-test/start_linux_test.go
+++ b/integration-test/start_linux_test.go
@@ -324,7 +324,7 @@ func (cs *ContainerdSuite) TestOOM(t *check.C) {
 	bundleName := "busybox-sh-512k-memlimit"
 	if err := CreateBundleWithFilter("busybox", bundleName, []string{"sh", "-c", "x=oom-party-time; while true; do x=$x$x$x$x$x$x$x$x$x$x; done"}, func(spec *ocs.Spec) {
 		// Limit to 512k for quick oom
-		var limit uint64 = 8 * 1024 * 1024
+		var limit int64 = 8 * 1024 * 1024
 		spec.Linux.Resources.Memory = &ocs.LinuxMemory{
 			Limit: &limit,
 		}

--- a/runtime/container_linux.go
+++ b/runtime/container_linux.go
@@ -112,11 +112,11 @@ func i64Ptr(i int64) *int64   { return &i }
 func (c *container) UpdateResources(r *Resource) error {
 	sr := ocs.LinuxResources{
 		Memory: &ocs.LinuxMemory{
-			Limit:       u64Ptr(uint64(r.Memory)),
-			Reservation: u64Ptr(uint64(r.MemoryReservation)),
-			Swap:        u64Ptr(uint64(r.MemorySwap)),
-			Kernel:      u64Ptr(uint64(r.KernelMemory)),
-			KernelTCP:   u64Ptr(uint64(r.KernelTCPMemory)),
+			Limit:       i64Ptr(r.Memory),
+			Reservation: i64Ptr(r.MemoryReservation),
+			Swap:        i64Ptr(r.MemorySwap),
+			Kernel:      i64Ptr(r.KernelMemory),
+			KernelTCP:   i64Ptr(r.KernelTCPMemory),
 		},
 		CPU: &ocs.LinuxCPU{
 			Shares: u64Ptr(uint64(r.CPUShares)),

--- a/vendor/src/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/src/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -281,16 +281,16 @@ type LinuxBlockIO struct {
 // LinuxMemory for Linux cgroup 'memory' resource management
 type LinuxMemory struct {
 	// Memory limit (in bytes).
-	Limit *uint64 `json:"limit,omitempty"`
+	Limit *int64 `json:"limit,omitempty"`
 	// Memory reservation or soft_limit (in bytes).
-	Reservation *uint64 `json:"reservation,omitempty"`
+	Reservation *int64 `json:"reservation,omitempty"`
 	// Total memory limit (memory + swap).
-	Swap *uint64 `json:"swap,omitempty"`
+	Swap *int64 `json:"swap,omitempty"`
 	// Kernel memory limit (in bytes).
-	Kernel *uint64 `json:"kernel,omitempty"`
+	Kernel *int64 `json:"kernel,omitempty"`
 	// Kernel memory limit for tcp (in bytes)
-	KernelTCP *uint64 `json:"kernelTCP,omitempty"`
-	// How aggressive the kernel will swap memory pages. Range from 0 to 100.
+	KernelTCP *int64 `json:"kernelTCP,omitempty"`
+	// How aggressive the kernel will swap memory pages.
 	Swappiness *uint64 `json:"swappiness,omitempty"`
 }
 


### PR DESCRIPTION
This vendors manually the runtime-spec that fixes the memory fields type from uint64 to int64.

I had issues running vendor.sh, so instead of cherry-picking https://github.com/containerd/containerd/pull/1137 which replaces vendor.sh with vndr, I manually changed the files in `vendor/`. We can always decide to get that PR in later.