### PR TITLE
[17.06] Don't fail containerd start in case of corrupted events.log

### DIFF
--- a/containerd/main.go
+++ b/containerd/main.go
@@ -152,10 +152,7 @@ func main() {
 		if p := context.GlobalString("pprof-address"); len(p) > 0 {
 			pprof.Enable(p)
 		}
-		if err := checkLimits(); err != nil {
-			return err
-		}
-		return nil
+		return checkLimits()
 	}
 
 	app.Action = func(context *cli.Context) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -27,10 +27,7 @@ func setup() error {
 		return err
 	}
 
-	if err := os.MkdirAll(utils.BundlesRoot, 0755); err != nil {
-		return err
-	}
-	return nil
+	return os.MkdirAll(utils.BundlesRoot, 0755)
 }
 
 // Creates the bundleDir with rootfs, io fifo dir and a default spec.

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -135,8 +135,11 @@ func readEventLog(s *Supervisor) error {
 		if err := dec.Decode(&e); err != nil {
 			if err == io.EOF {
 				break
+			} else {
+				// We dont want to prevent containerd from starting if the events.log was corrupted
+				logrus.WithField("error", err).Warnf("containerd: Cannot parse event. Skipping.")
+				break
 			}
-			return err
 		}
 
 		// We need to take care of -1 Status for backward compatibility


### PR DESCRIPTION
back port of https://github.com/containerd/containerd/pull/1720 for 17.06

Some host crash scenarious might cause a corruption at the end of the
events.log. In those cases, the file ends with multiple 0x00 (assuming
that were created for journaling of an event prior the crash).
In such case, there is no meaning of preventing containerd from starting.
This commit add a logic of ignoring the rest of the file (it should be a single event
that is missing anyhow) and proceed with those that were succesfully parsed so far.

Tested using the corrupted log attached to the github issue.

Signed-off-by: Rom Freiman <rom@stratoscale.com>
(cherry picked from commit 3b3a98cca1d0023a2005141948508cd610d72485)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>