### PR TITLE
[17.06] switch to docker/runc version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ addons:
       - curl
 
 env:
-  - SECCOMP_VERSION=2.3.1 RUNC_COMMIT=992a5be178a62e026f4069f443c6164912adbf09
+  # Runc is built from the 17.06 branch in https://github.com/docker/runc
+  # when updating, also update the Dockerfile and hack/vendor.sh accordingly
+  - SECCOMP_VERSION=2.3.1 RUNC_COMMIT=519d2ac975245b241773455f43db39bf6b8f40c8
 
 
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,11 +58,12 @@ RUN set -x \
 	) \
 	&& rm -rf "$SECCOMP_PATH"
 
-# Install runc
-ENV RUNC_COMMIT 992a5be178a62e026f4069f443c6164912adbf09
+# Install runc from the 17.06 branch in https://github.com/docker/runc
+# when updating, also update hack/vendor.sh and .travis.yml accordingly
+ENV RUNC_COMMIT 519d2ac975245b241773455f43db39bf6b8f40c8
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
-    && git clone git://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
+    && git clone git://github.com/docker/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
 	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
 	&& git checkout -q "$RUNC_COMMIT" \
 	&& make BUILDTAGS="seccomp apparmor selinux" && make install

--- a/hack/install-runc.sh
+++ b/hack/install-runc.sh
@@ -3,7 +3,9 @@
 set -e
 
 export GOPATH="$(mktemp -d)"
-git clone git://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
+
+# Runc is built from the 17.06 branch in https://github.com/docker/runc
+git clone git://github.com/docker/runc.git "$GOPATH/src/github.com/opencontainers/runc"
 cd "$GOPATH/src/github.com/opencontainers/runc"
 git checkout -q "$RUNC_COMMIT"
 make BUILDTAGS="seccomp apparmor selinux"


### PR DESCRIPTION
The 17.06 packages are built with a runc version built from the
17.06 branch on the docker/runc repository. The docker/runc 17.06
branch is based on the upstream 0.2.x branch, but contains backports
from upstream.

This patch switches CI, and the Dockerfile to use that repository,
so that CI is testing against the same version.


~I also switch the vendored version to docker/runc, but this did not introduce local changes~

no idea how to make the vendoring work properly 😞 