### PR TITLE
Make addProcess() parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ sudo: required
 language: go
 
 go:
-  - 1.8.x
-  - tip
+  - 1.10.x
 
 go_import_path: github.com/containerd/containerd
 

--- a/supervisor/add_process.go
+++ b/supervisor/add_process.go
@@ -27,25 +27,30 @@ func (s *Supervisor) addProcess(t *AddProcessTask) error {
 	if !ok {
 		return ErrContainerNotFound
 	}
-	process, err := ci.container.Exec(t.Ctx(), t.PID, *t.ProcessSpec, runtime.NewStdio(t.Stdin, t.Stdout, t.Stderr))
-	if err != nil {
-		return err
-	}
-	s.newExecSyncChannel(t.ID, t.PID)
-	if err := s.monitorProcess(process); err != nil {
-		s.deleteExecSyncChannel(t.ID, t.PID)
-		// Kill process
-		process.Signal(os.Kill)
-		ci.container.RemoveProcess(t.PID)
-		return err
-	}
-	ExecProcessTimer.UpdateSince(start)
-	t.StartResponse <- StartResponse{ExecPid: process.SystemPid()}
-	s.notifySubscribers(Event{
-		Timestamp: time.Now(),
-		Type:      StateStartProcess,
-		PID:       t.PID,
-		ID:        t.ID,
-	})
-	return nil
+	go func() {
+		process, err := ci.container.Exec(t.Ctx(), t.PID, *t.ProcessSpec, runtime.NewStdio(t.Stdin, t.Stdout, t.Stderr))
+		if err != nil {
+			t.errCh <- err
+			return
+		}
+		s.newExecSyncChannel(t.ID, t.PID)
+		if err := s.monitorProcess(process); err != nil {
+			s.deleteExecSyncChannel(t.ID, t.PID)
+			// Kill process
+			process.Signal(os.Kill)
+			ci.container.RemoveProcess(t.PID)
+			t.errCh <- err
+			return
+		}
+		ExecProcessTimer.UpdateSince(start)
+		t.errCh <- nil
+		t.StartResponse <- StartResponse{ExecPid: process.SystemPid()}
+		s.notifySubscribers(Event{
+			Timestamp: time.Now(),
+			Type:      StateStartProcess,
+			PID:       t.PID,
+			ID:        t.ID,
+		})
+	}()
+	return errDeferredResponse
 }


### PR DESCRIPTION
Following Crosby's patch, this commit makes launching health-check processes faster when many health-checks occur simultaneously.
It helps avoiding health-check timeouts that Paypal ran into. (FIELD-2190)
In addition, this commit adds a lock to protect accessing to 'processes' map of the container.

Signed-off-by: Xinfeng Liu <xinfeng.liu@gmail.com>