### PR TITLE
 Fixing Travis CI and use go 1.10 and later versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ sudo: required
 language: go
 
 go:
-  - 1.8.x
-  - tip
+  - 1.10.x
 
 go_import_path: github.com/containerd/containerd
 
@@ -23,7 +22,7 @@ env:
 install:
   - hack/install-seccomp.sh
   - hack/install-runc.sh
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
 
 script:
   - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: go
 
 go:
   - 1.10.x
+  - 1.12.x
+  - 1.13.x
+  - tip
 
 go_import_path: github.com/containerd/containerd
 

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ shell: dbuild
 	$(DOCKER_RUN) bash
 
 test: validate install bundles-rootfs
-	go test -bench=. -v $(shell go list ./... | grep -v /vendor | grep -v /integration-test ) -runtime=$(RUNTIME)
+	go test -bench=. -v $(shell go list ./... | grep -v -e /vendor -e /integration-test -e /pprof) -runtime=$(RUNTIME)
 ifneq ($(wildcard /.dockerenv), )
 	cd integration-test ; \
 go test -check.v -check.timeout=$(TEST_TIMEOUT) $(TESTFLAGS) timeout=$(TEST_SUITE_TIMEOUT) github.com/containerd/containerd/integration-test
@@ -98,10 +98,10 @@ endif
 
 integration-test:
 	cd integration-test ; \
-go test -check.v -check.timeout=$(TEST_TIMEOUT) $(TESTFLAGS) timeout=$(TEST_SUITE_TIMEOUT) github.com/containerd/containerd/integration-test
+go test -parallel 1 -check.v -check.timeout=$(TEST_TIMEOUT) $(TESTFLAGS) timeout=$(TEST_SUITE_TIMEOUT) github.com/containerd/containerd/integration-test
 
 bench: shim validate install bundles-rootfs
-	go test -bench=. -v $(shell go list ./... | grep -v /vendor | grep -v /integration-test) -runtime=$(RUNTIME)
+	go test -bench=. -v $(shell go list ./... | grep -v -e /vendor -e /integration-test -e /pprof) -runtime=$(RUNTIME)
 
 validate: fmt lint
 

--- a/integration-test/exec_test.go
+++ b/integration-test/exec_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -58,7 +59,7 @@ func (cs *ContainerdSuite) TestBusyboxTopExecEcho(t *check.C) {
 		t.Assert(*e, checker.Equals, evt)
 	}
 
-	t.Assert(echop.io.stdoutBuffer.String(), checker.Equals, "Ay Caramba!")
+	t.Assert(strings.TrimRight(echop.io.stdoutBuffer.String(), string('\x00')), checker.Equals, "Ay Caramba!")
 }
 
 func (cs *ContainerdSuite) TestBusyboxTopExecTop(t *check.C) {

--- a/integration-test/start_linux_test.go
+++ b/integration-test/start_linux_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -439,7 +440,7 @@ func (cs *ContainerdSuite) TestRestart(t *check.C) {
 
 		t.Assert(*e, checker.Equals, evt)
 	}
-	t.Assert(echop.io.stdoutBuffer.String(), checker.Equals, "Success!")
+	t.Assert(strings.TrimRight(echop.io.stdoutBuffer.String(), string('\x00')), checker.Equals, "Success!")
 
 	// Now kill daemon (SIGKILL)
 	cs.StopDaemon(true)


### PR DESCRIPTION
- Need to upgrade go 1.10 and later to fix "go get -u github.com/golang/lint/golint" error in travis CI.
See: https://github.com/golang/lint/issues/421

- Also modify integration test code to make it pass the CI when using golang 1.10.x.

- Replace "github.com/golang/lint/golint" with "golang.org/x/lint/golint" (This is needed for golang 1.12 or later)

- Modify `Makefile` to fix `make test` error when using go 1.12 or later.

Signed-off-by: Xinfeng Liu <xinfeng.liu@gmail.com>